### PR TITLE
Local Peristence, Room Integration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
+    id("com.google.devtools.ksp")
 }
 
 android {
@@ -59,6 +60,8 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.androidx.room.runtime.android)
+    ksp(libs.androidx.room.compiler)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/harrison/kurt/exercise/fetch/MainActivity.kt
+++ b/app/src/main/java/harrison/kurt/exercise/fetch/MainActivity.kt
@@ -11,6 +11,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.room.Room
+import harrison.kurt.exercise.fetch.listitem.persistence.ListItemDatabase
+import harrison.kurt.exercise.fetch.listitem.persistence.ListItemEntity
 import harrison.kurt.exercise.fetch.ui.theme.FetchTheme
 
 class MainActivity : ComponentActivity() {
@@ -27,6 +30,23 @@ class MainActivity : ComponentActivity() {
                 }
             }
         }
+        dbTest()
+    }
+
+    /**
+     * Test showing basic setup
+     */
+    private fun dbTest() {
+        Thread {
+            val db = Room.databaseBuilder(
+                applicationContext,
+                ListItemDatabase::class.java,
+                "list-items-db"
+            ).build()
+            val dao = db.listItemDao()
+            val entity = ListItemEntity(0,0, "foo")
+            dao.insertAll(entity)
+        }.start()
     }
 }
 

--- a/app/src/main/java/harrison/kurt/exercise/fetch/listitem/persistence/ListItemDao.kt
+++ b/app/src/main/java/harrison/kurt/exercise/fetch/listitem/persistence/ListItemDao.kt
@@ -1,0 +1,32 @@
+package harrison.kurt.exercise.fetch.listitem.persistence
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+/**
+ * A basic data access object providing an interface to perform needed database operations.
+ */
+@Dao
+interface ListItemDao {
+    /**
+     * Returns all stored items.
+     */
+    @Query("SELECT * FROM list_item")
+    fun getAll(): List<ListItemEntity>
+
+    /**
+     * Inserts all provided list items into the local database.
+     * Existing entries are replaced with newer instances.
+     */
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    fun insertAll(vararg items: ListItemEntity)
+
+    /**
+     * Removes a list item from the database.
+     */
+    @Delete
+    fun delete(item: ListItemEntity)
+}

--- a/app/src/main/java/harrison/kurt/exercise/fetch/listitem/persistence/ListItemDatabase.kt
+++ b/app/src/main/java/harrison/kurt/exercise/fetch/listitem/persistence/ListItemDatabase.kt
@@ -1,0 +1,17 @@
+package harrison.kurt.exercise.fetch.listitem.persistence
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+
+/**
+ * A simple definition of a Room/SQLite database to store list items. An interface of available
+ * operations is queryable. This database is comprised of a single table containing a single kind of
+ * entity, [ListItemEntity].
+ */
+@Database(entities = [ListItemEntity::class], version = 1)
+abstract class ListItemDatabase : RoomDatabase() {
+    /**
+     * Provides an interface to perform database operations. See [ListItemDao] for more usage.
+     */
+    abstract fun listItemDao(): ListItemDao
+}

--- a/app/src/main/java/harrison/kurt/exercise/fetch/listitem/persistence/ListItemEntity.kt
+++ b/app/src/main/java/harrison/kurt/exercise/fetch/listitem/persistence/ListItemEntity.kt
@@ -1,0 +1,16 @@
+package harrison.kurt.exercise.fetch.listitem.persistence
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * Definition of list item entities. List items are stored in a table named "list_item".
+ */
+@Entity(tableName = "list_item")
+data class ListItemEntity(
+    @PrimaryKey val id: Int,
+    // Column renamed to adhere to both SQLite and Kotlin naming conventions.
+    @ColumnInfo(name = "list_id") val listId: Int,
+    val name: String?,
+)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,4 +2,5 @@
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
+    id("com.google.devtools.ksp") version "1.9.0-1.0.13" apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,9 +8,15 @@ espressoCore = "3.6.1"
 lifecycleRuntimeKtx = "2.8.6"
 activityCompose = "1.9.2"
 composeBom = "2024.04.01"
+roomCompiler = "2.6.1"
+roomCompilerVersion = "2.5.0"
+roomRuntimeAndroid = "2.7.0-alpha08"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "roomCompiler" }
+androidx-room-compiler-v250 = { module = "androidx.room:room-compiler", version.ref = "roomCompilerVersion" }
+androidx-room-runtime-android = { module = "androidx.room:room-runtime-android", version.ref = "roomRuntimeAndroid" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }


### PR DESCRIPTION
The approach to persist data locally provides the ability to implement an offline-first approach to fetching data. Data will be loaded from persisted data while datasets changed are pulled down from online sources.

Required dependencies added for Jetpack Room. Room provides an abstraction for SQLite, a database solution natively supported on the Android platform. A simple database tracking list items is implemented.